### PR TITLE
Allow unlisted commodityv3 fields to be ignored

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'io.edpn.backend'
-version = '0.0.5-SNAPSHOT'
+version = '0.0.6-SNAPSHOT'
 compileJava.options.encoding = 'UTF-8'
 
 java {
@@ -32,7 +32,7 @@ repositories {
 }
 
 ext {
-    backendUtilVersion = '0.0.4-SNAPSHOT'
+    backendUtilVersion = '0.0.3-SNAPSHOT'
     jacksonVersion = '2.14.2'
     junitJupiterVersion = "5.9.3"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 ext {
-    backendUtilVersion = '0.0.3-SNAPSHOT'
+    backendUtilVersion = '0.0.4-SNAPSHOT'
     jacksonVersion = '2.14.2'
     junitJupiterVersion = "5.9.3"
 }

--- a/src/main/java/io/edpn/backend/messageprocessorlib/application/dto/eddn/CommodityMessage.java
+++ b/src/main/java/io/edpn/backend/messageprocessorlib/application/dto/eddn/CommodityMessage.java
@@ -1,5 +1,6 @@
 package io.edpn.backend.messageprocessorlib.application.dto.eddn;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.edpn.backend.util.TimestampConverter;
 import java.time.LocalDateTime;
@@ -16,7 +17,8 @@ public interface CommodityMessage {
         public LocalDateTime messageTimeStamp() {
             return TimestampConverter.convertToLocalDateTime(message.timestamp());
         }
-
+        
+        @JsonIgnoreProperties(ignoreUnknown = true)
         public record Payload(
                 @JsonProperty("systemName") String systemName,
                 @JsonProperty("stationName") String stationName,


### PR DESCRIPTION
Backend currently hangs whenever it encounters a field not explicitly listed

Currently an issue for Commodity.V3

May be worth adding to all classes, we dont want an upstream change to break our backend. We should strive for concurrency but the defauly when encountering an unexpected field should be to ignore it. 